### PR TITLE
add missing deposit tokens across EVM chains and Solana

### DIFF
--- a/arbitrum.json
+++ b/arbitrum.json
@@ -971,5 +971,18 @@
     ],
     "coingeckoId": "hall-of-legends",
     "chainId": 42161
+  },
+  {
+    "symbol": "APE",
+    "name": "ApeCoin",
+    "decimals": 18,
+    "address": "0x7f9fbf9bdd3f4105c478b996b648fe6e828a1e98",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/24383/large/APECOIN.png?1756551529",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "apecoin",
+    "chainId": 42161
   }
 ]

--- a/avalanche.json
+++ b/avalanche.json
@@ -1037,5 +1037,33 @@
     ],
     "coingeckoId": "bingo-3",
     "chainId": 43114
+  },
+  {
+    "symbol": "GUN",
+    "name": "GUN",
+    "decimals": 18,
+    "address": "0x26debd39d5ed069770406fca10a0e4f8d2c743eb",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/55027/large/gunz.jpg?1743262298",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "gunz",
+    "chainId": 43114
+  },
+  {
+    "symbol": "USDe",
+    "name": "USDe",
+    "decimals": 18,
+    "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059",
+    "tags": [
+      "crosschain",
+      "GROUP:USDE",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "ethena-usde",
+    "chainId": 43114
   }
 ]

--- a/base.json
+++ b/base.json
@@ -1129,5 +1129,31 @@
     ],
     "coingeckoId": "base-is-for-everyone",
     "chainId": 8453
+  },
+  {
+    "symbol": "SYND",
+    "name": "Syndicate",
+    "decimals": 18,
+    "address": "0x11dc28d01984079b7efe7763b533e6ed9e3722b9",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/69122/large/synd.png?1757576144",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "syndicate-3",
+    "chainId": 8453
+  },
+  {
+    "symbol": "SOL",
+    "name": "Solana",
+    "decimals": 9,
+    "address": "0x311935cd80b76769bf2ecc9d8ab7635b2139cf82",
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "solana",
+    "chainId": 8453
   }
 ]

--- a/bsc.json
+++ b/bsc.json
@@ -4971,5 +4971,33 @@
     ],
     "coingeckoId": "bad-coin",
     "chainId": 56
+  },
+  {
+    "symbol": "SOMI",
+    "name": "Somnia",
+    "decimals": 18,
+    "address": "0xa9616e5e23ec1582c2828b025becf3ef610e266f",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68061/large/somi-token-roundel-1.png?1776903324",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "somnia",
+    "chainId": 56
+  },
+  {
+    "symbol": "USDe",
+    "name": "USDe",
+    "decimals": 18,
+    "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059",
+    "tags": [
+      "crosschain",
+      "GROUP:USDE",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "ethena-usde",
+    "chainId": 56
   }
 ]

--- a/ethereum.json
+++ b/ethereum.json
@@ -12360,5 +12360,48 @@
     ],
     "coingeckoId": "smardex-wrapped-usdn",
     "chainId": 1
+  },
+  {
+    "symbol": "SYND",
+    "name": "Syndicate",
+    "decimals": 18,
+    "address": "0x1bab804803159ad84b8854581aa53ac72455614e",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/69122/large/synd.png?1757576144",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "syndicate-3",
+    "chainId": 1
+  },
+  {
+    "symbol": "mUSD",
+    "name": "MetaMask USD",
+    "decimals": 6,
+    "address": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68451/large/MetaMask-mUSD-Icon-200x200.png?1755878384",
+    "tags": [
+      "crosschain",
+      "GROUP:MUSD",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "metamask-usd",
+    "chainId": 1
+  },
+  {
+    "symbol": "USDG",
+    "name": "Global Dollar",
+    "decimals": 6,
+    "address": "0xe343167631d89b6ffc58b88d6b7fb0228795491d",
+    "logoURI": "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/GDN-USDG-Token-512x512.png",
+    "tags": [
+      "crosschain",
+      "GROUP:USDG",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "global-dollar",
+    "chainId": 1
   }
 ]

--- a/monad.json
+++ b/monad.json
@@ -6,7 +6,7 @@
     "address": "0x0000000000000000000000000000000000000000",
     "logoURI": "https://raw.githubusercontent.com/kanalabs/token-lists/main/icons/MOD.png",
     "tags": ["tokens"],
-    "coingeckoId": "",
+    "coingeckoId": "monad",
     "chainId": 13
   },  
   {
@@ -211,5 +211,35 @@
     "tags": ["tokens"],
     "coingeckoId": "",
     "chainId": 13
+  },
+  {
+    "symbol": "USDC",
+    "name": "USD Coin",
+    "decimals": 6,
+    "address": "0x754704bc059f8c67012fed69bc8a327a5aafb603",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/USDC.png?1769615602",
+    "tags": [
+      "crosschain",
+      "GROUP:USDC",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usd-coin",
+    "chainId": 143
+  },
+  {
+    "symbol": "mUSD",
+    "name": "MetaMask USD",
+    "decimals": 6,
+    "address": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68451/large/MetaMask-mUSD-Icon-200x200.png?1755878384",
+    "tags": [
+      "crosschain",
+      "GROUP:MUSD",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "metamask-usd",
+    "chainId": 143
   }
 ]

--- a/solana.json
+++ b/solana.json
@@ -9927,5 +9927,16 @@
     "extensions": {
       "coingeckoId": "new-ancient-dna-cloned-wolf"
     }
+  },
+  {
+    "address": "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH",
+    "chainId": 101,
+    "decimals": 6,
+    "name": "CASH",
+    "symbol": "CASH",
+    "logoURI": "https://token-metadata.bridge.xyz/images/cash.png",
+    "extensions": {
+      "coingeckoId": "cash-4"
+    }
   }
 ]


### PR DESCRIPTION
Adds 13 tokens used by the deposit-address flow and sets Monad MON's missing coingeckoId so it prices correctly.