### PR TITLE
add optimism, hyperEvm, ink and robinhood token lists

### DIFF
--- a/bitcoin.json
+++ b/bitcoin.json
@@ -1,0 +1,15 @@
+[
+  {
+    "symbol": "BTC",
+    "name": "Bitcoin",
+    "decimals": 8,
+    "address": "bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqmql8k8",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/1/large/bitcoin.png?1696501400",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "bitcoin",
+    "chainId": 8253038
+  }
+]

--- a/hyperEvm.json
+++ b/hyperEvm.json
@@ -1,0 +1,60 @@
+[
+  {
+    "symbol": "HYPE",
+    "name": "HYPE",
+    "decimals": 18,
+    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/50882/large/hyperliquid.jpg?1729431300",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "hyperliquid",
+    "chainId": 999
+  },
+  {
+    "symbol": "USDC",
+    "name": "USDC",
+    "decimals": 6,
+    "address": "0xb88339cb7199b77e23db6e890353e22632ba630f",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/USDC.png?1769615602",
+    "tags": [
+      "crosschain",
+      "GROUP:USDC",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usd-coin",
+    "chainId": 999
+  },
+  {
+    "symbol": "USD₮0",
+    "name": "USD₮0",
+    "decimals": 6,
+    "address": "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183",
+    "tags": [
+      "crosschain",
+      "GROUP:USDT",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usdt0",
+    "chainId": 999
+  },
+  {
+    "symbol": "USDe",
+    "name": "USDeOFT",
+    "decimals": 18,
+    "address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059",
+    "tags": [
+      "crosschain",
+      "GROUP:USDE",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "ethena-usde",
+    "chainId": 999
+  }
+]

--- a/ink.json
+++ b/ink.json
@@ -1,0 +1,45 @@
+[
+  {
+    "symbol": "ETH",
+    "name": "Ether",
+    "decimals": 18,
+    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/279/large/ethereum.png?1696501628",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "ethereum",
+    "chainId": 57073
+  },
+  {
+    "symbol": "USDC",
+    "name": "USDC",
+    "decimals": 6,
+    "address": "0x2d270e6886d130d724215a266106e6832161eaed",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/USDC.png?1769615602",
+    "tags": [
+      "crosschain",
+      "GROUP:USDC",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usd-coin",
+    "chainId": 57073
+  },
+  {
+    "symbol": "USDT0",
+    "name": "Tether USDT",
+    "decimals": 6,
+    "address": "0x0200c29006150606b650577bbe7b6248f58470c1",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183",
+    "tags": [
+      "crosschain",
+      "GROUP:USDT",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usdt0",
+    "chainId": 57073
+  }
+]

--- a/optimism.json
+++ b/optimism.json
@@ -1,0 +1,58 @@
+[
+  {
+    "symbol": "ETH",
+    "name": "Ether",
+    "decimals": 18,
+    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/279/large/ethereum.png?1696501628",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "ethereum",
+    "chainId": 10
+  },
+  {
+    "symbol": "USDC",
+    "name": "USD Coin",
+    "decimals": 6,
+    "address": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/USDC.png?1769615602",
+    "tags": [
+      "crosschain",
+      "GROUP:USDC",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "usd-coin",
+    "chainId": 10
+  },
+  {
+    "symbol": "USDT",
+    "name": "Tether USD",
+    "decimals": 6,
+    "address": "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/325/large/Tether.png?1696501661",
+    "tags": [
+      "crosschain",
+      "GROUP:USDT",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "tether",
+    "chainId": 10
+  },
+  {
+    "symbol": "WETH",
+    "name": "Wrapped Ether",
+    "decimals": 18,
+    "address": "0x4200000000000000000000000000000000000006",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/2518/large/weth.png?1696503332",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "weth",
+    "chainId": 10
+  }
+]

--- a/robinhood.json
+++ b/robinhood.json
@@ -1,0 +1,30 @@
+[
+  {
+    "symbol": "ETH",
+    "name": "Ether",
+    "decimals": 18,
+    "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/279/large/ethereum.png?1696501628",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "ethereum",
+    "chainId": 4663
+  },
+  {
+    "symbol": "USDG",
+    "name": "Global Dollar",
+    "decimals": 6,
+    "address": "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+    "logoURI": "https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/GDN-USDG-Token-512x512.png",
+    "tags": [
+      "crosschain",
+      "GROUP:USDG",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "global-dollar",
+    "chainId": 4663
+  }
+]

--- a/tron.json
+++ b/tron.json
@@ -1,0 +1,29 @@
+[
+  {
+    "symbol": "USDT",
+    "name": "Tether USD",
+    "decimals": 6,
+    "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/325/large/Tether.png?1696501661",
+    "tags": [
+      "crosschain",
+      "PEG:USD",
+      "tokens"
+    ],
+    "coingeckoId": "tether",
+    "chainId": 728126428
+  },
+  {
+    "symbol": "TRX",
+    "name": "TRON",
+    "decimals": 6,
+    "address": "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/1094/large/photo_2026-04-13_09-59-16.png?1776048311",
+    "tags": [
+      "crosschain",
+      "tokens"
+    ],
+    "coingeckoId": "tron",
+    "chainId": 728126428
+  }
+]


### PR DESCRIPTION
Adds token lists for four new EVM chains, consumed by the deposit-address flow once the matching chain ids land in utilities.