### PR TITLE
Replace dead 1inch logo URLs for cbBTC, DEGEN, USDT and ANIME

### DIFF
--- a/arbitrum.json
+++ b/arbitrum.json
@@ -358,7 +358,7 @@
     "name": "Animecoin",
     "decimals": 18,
     "address": "0x37a645648df29205c6261289983fb04ecd70b4b3",
-    "logoURI": "https://tokens-data.1inch.io/images/42161/0x37a645648df29205c6261289983fb04ecd70b4b3_0x93fe1ce4d7d74895613cea4d5e6b54d2d38703230f5f3d783a205d4632a46168.webp",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53575/large/anime.jpg?1736748703",
     "tags": [
       "crosschain",
       "GROUP:ANIME",

--- a/base.json
+++ b/base.json
@@ -49,7 +49,7 @@
     "name": "Coinbase Wrapped BTC",
     "decimals": 8,
     "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
-    "logoURI": "https://tokens-data.1inch.io/images/8453/0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf.webp",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727",
     "tags": [
       "crosschain",
       "GROUP:CBBTC",
@@ -383,7 +383,7 @@
     "name": "Tether USD",
     "decimals": 6,
     "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
-    "logoURI": "https://tokens-data.1inch.io/images/8453/0xfde4c96c8593536e31f229ea8f37b2ada2699bb2_0x8a5ac04932b14c381524b5777f2707dd269115abdc2eecd05ab06800d5bbe277.webp",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39963/large/usdt.png?1724952731",
     "tags": [
       "crosschain",
       "PEG:USD",
@@ -480,7 +480,7 @@
     "name": "Degen",
     "decimals": 18,
     "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
-    "logoURI": "https://tokens-data.1inch.io/images/8453/0x4ed4e862860bed51a9570b96d89af5e1b0efefed.webp",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225",
     "tags": [
       "tokens"
     ],


### PR DESCRIPTION
These four logoURIs return 403 from tokens-data.1inch.io, so the tokens render a fallback badge; swapped to CoinGecko images matched by contract address.